### PR TITLE
feat: add salt option to registration

### DIFF
--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -443,3 +443,8 @@ module.exports.bulkProducts = function (req, res) {
     res.render('app/bulkproducts', { messages: { danger: 'Invalid file' }, legacy: false })
   }
 }
+
+module.exports.resetdb = function(req, res){
+  return db.sequelize.query("DELETE FROM Users")
+    .then(()=>res.status(201).send("All User records deleted.")); 
+}

--- a/models/user.js
+++ b/models/user.js
@@ -28,6 +28,10 @@ module.exports = function (sequelize, DataTypes) {
             type: DataTypes.STRING,
             allowNull: false
         },
+        salt: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
         role: {
             type: DataTypes.STRING,
             allowNull: true

--- a/routes/app.js
+++ b/routes/app.js
@@ -3,161 +3,110 @@ var appHandler = require("../core/appHandler");
 var authHandler = require("../core/authHandler");
 
 module.exports = function () {
-  router.get("/", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    res.redirect("/learn");
-  });
+    router.get('/', authHandler.isAuthenticated, function (req, res) {
+        res.redirect('/learn')
+    })
 
-  router.get("/usersearch", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    res.render("app/usersearch", {
-      output: null,
-      securityRating: req.query.securityRating,
-    });
-  });
+    router.get('/usersearch', authHandler.isAuthenticated, function (req, res) {
+        res.render('app/usersearch', {
+            output: null,
+            securityRating: req.query.securityRating
+        })
+    })
 
-  router.get("/ping", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    res.render("app/ping", {
-      output: null,
-      securityRating: req.query.securityRating,
-    });
-  });
+    router.get('/ping', authHandler.isAuthenticated, function (req, res) {
+        res.render('app/ping', {
+            output: null,
+            securityRating: req.query.securityRating
+        })
+    })
 
-  router.get("/bulkproducts", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    res.render("app/bulkproducts", { legacy: req.query.legacy });
-  });
+    router.get('/bulkproducts', authHandler.isAuthenticated, function (req, res) {
+        res.render('app/bulkproducts',{legacy:req.query.legacy})
+    })
 
-  router.get("/products", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.listProducts);
+    router.get('/products', authHandler.isAuthenticated, appHandler.listProducts)
 
-  router.get(
-    "/modifyproduct",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    appHandler.modifyProduct
-  );
+    router.get('/modifyproduct', authHandler.isAuthenticated, appHandler.modifyProduct)
 
-  router.get("/useredit", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.userEdit);
+    router.get('/useredit', authHandler.isAuthenticated, appHandler.userEdit)
 
-  router.get("/calc", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    res.render("app/calc", { output: null });
-  });
+    router.get('/calc', authHandler.isAuthenticated, function (req, res) {
+        res.render('app/calc',{output:null})
+    })
 
-  router.get("/admin", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
-    var globalRating = req.session.ratingState[req.query.vuln];
-    res.render("app/admin", {
-      admin: req.user.role == "admin",
-      securityRating: globalRating,
-      vuln: req.query.vuln,
-    });
-  });
+    router.get('/admin', authHandler.isAuthenticated, function (req, res) {
+        var globalRating = ratingState[req.query.vuln]
+        res.render('app/admin', {
+            admin: (req.user.role == 'admin'),
+            securityRating: globalRating,
+            vuln: req.query.vuln
+        })
+    })
 
-  router.get(
-    "/admin/usersapi/",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    authHandler.isAdmin,
-    appHandler.listUsersAPI
-  );
+    router.get('/admin/usersapi/', authHandler.isAuthenticated, authHandler.isAdmin, appHandler.listUsersAPI)
 
-  router.get(
-    "/admin/users/",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    authHandler.isAdmin,
-    function (req, res) {
-      vuln3 = "a3_sensitive_data";
-      vuln5 = "a5_broken_access_control";
-      var a3Rating = req.session.ratingState["a3_sensitive_data"];
-      var a5Rating = req.session.ratingState["a5_broken_access_control"];
-      res.render("app/adminusers", {
-        a3Rating: a3Rating,
-        a5Rating: a5Rating,
-        admin: req.user.role,
-        vuln3: vuln3,
-        vuln5: vuln5,
-      });
-    }
-  );
+    router.get('/admin/users/', authHandler.isAuthenticated, authHandler.isAdmin,function(req, res){
+        vuln3 = 'a3_sensitive_data'
+        vuln5 = 'a5_broken_access_control'
+        var a3Rating = ratingState['a3_sensitive_data']
+        var a5Rating = ratingState['a5_broken_access_control']
+        res.render('app/adminusers', {
+            a3Rating: a3Rating,
+            a5Rating: a5Rating,
+            admin: req.user.role,
+            vuln3: vuln3,
+            vuln5: vuln5
+        })
+    })
 
-  router.get(
-    "/admin/users/toggle",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    function (req, res) {
-      if (req.session.ratingState[req.query.vuln] == 1)
-        req.session.ratingState[req.query.vuln] = 0;
-      else req.session.ratingState[req.query.vuln] = 1;
-      res.redirect("/app/admin/users/");
-    }
-  );
+    router.get('/admin/users/toggle', authHandler.isAuthenticated, function (req, res) {
+        if(ratingState[req.query.vuln] == 1)
+            ratingState[req.query.vuln] = 0
+        else
+            ratingState[req.query.vuln] = 1
+        res.redirect('/app/admin/users/')
+    })
 
-  router.get(
-    "/admin/toggle/a5",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    function (req, res) {
-      if (req.session.ratingState["a5_broken_access_control"] == 1)
-        req.session.ratingState["a5_broken_access_control"] = 0;
-      else req.session.ratingState["a5_broken_access_control"] = 1;
-      res.render("app/admin", {
-        admin: req.user.dataValues.role == "admin",
-        securityRating: req.session.ratingState["a5_broken_access_control"],
-        vuln: "a5_broken_access_control",
-      });
-    }
-  );
+    router.get('/admin/toggle/a5', authHandler.isAuthenticated, function (req, res) {
+        if(ratingState['a5_broken_access_control'] == 1)
+            ratingState['a5_broken_access_control'] = 0
+        else
+            ratingState['a5_broken_access_control'] = 1
+        res.render('app/admin', {
+            admin: (req.user.dataValues.role == 'admin'),
+            securityRating: ratingState['a5_broken_access_control'],
+            vuln: 'a5_broken_access_control'
+        })
+    })
+   
+    router.get('/redirect', appHandler.redirect)
 
-  router.get("/redirect", appHandler.redirect);
+    router.post('/usersearch', authHandler.isAuthenticated, appHandler.userSearch)
 
-  router.post(
-    "/usersearch",
-    authHandler.isAuthenticated, authHandler.initializeRatingState,
-    appHandler.userSearch
-  );
+    router.post('/ping', authHandler.isAuthenticated, appHandler.ping)
 
-  router.post("/ping", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.ping);
+    router.post('/products', authHandler.isAuthenticated, appHandler.productSearch)
 
-  router.post(
-    "/products",
-    authHandler.isAuthenticated, authHandler.initializeRatingState, 
-    appHandler.productSearch
-  );
+    router.post('/modifyproduct', authHandler.isAuthenticated, appHandler.modifyProductSubmit)
 
-  router.post(
-    "/modifyproduct",
-    authHandler.isAuthenticated, authHandler.initializeRatingState, 
-    appHandler.modifyProductSubmit
-  );
+    router.post('/useredit', authHandler.isAuthenticated, appHandler.userEditSubmit)
 
-  router.post(
-    "/useredit",
-    authHandler.isAuthenticated, authHandler.initializeRatingState, 
-    appHandler.userEditSubmit
-  );
+    router.get('/useredit/toggle', authHandler.isAuthenticated, function (req, res) {
+        if(ratingState[req.query.vuln] == 1)
+            ratingState[req.query.vuln] = 0
+        else
+            ratingState[req.query.vuln] = 1
+        res.redirect('/app/useredit/')
+    })
 
-  router.get(
-    "/useredit/toggle",
-    authHandler.isAuthenticated,
-    authHandler.initializeRatingState,
-    function (req, res) {
-      if (req.session.ratingState[req.query.vuln] == 1)
-        req.session.ratingState[req.query.vuln] = 0;
-      else req.session.ratingState[req.query.vuln] = 1;
-      res.redirect("/app/useredit/");
-    }
-  );
+    router.post('/calc', authHandler.isAuthenticated, appHandler.calc)
 
-  router.post("/calc", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.calc);
+    router.post('/bulkproducts',authHandler.isAuthenticated, appHandler.bulkProducts);
 
-  router.post(
-    "/bulkproducts",
-    authHandler.isAuthenticated, authHandler.initializeRatingState, 
-    appHandler.bulkProducts
-  );
+    router.post('/bulkproductslegacy',authHandler.isAuthenticated, appHandler.bulkProductsLegacy);
 
-  router.post(
-    "/bulkproductslegacy",
-    authHandler.isAuthenticated, authHandler.initializeRatingState, 
-    appHandler.bulkProductsLegacy
-  );
-
-  return router;
-};
+    router.get('/reset-db', appHandler.resetdb);
+    
+    return router
+}

--- a/routes/app.js
+++ b/routes/app.js
@@ -3,110 +3,163 @@ var appHandler = require("../core/appHandler");
 var authHandler = require("../core/authHandler");
 
 module.exports = function () {
-    router.get('/', authHandler.isAuthenticated, function (req, res) {
-        res.redirect('/learn')
-    })
+  router.get("/", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    res.redirect("/learn");
+  });
 
-    router.get('/usersearch', authHandler.isAuthenticated, function (req, res) {
-        res.render('app/usersearch', {
-            output: null,
-            securityRating: req.query.securityRating
-        })
-    })
+  router.get("/usersearch", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    res.render("app/usersearch", {
+      output: null,
+      securityRating: req.query.securityRating,
+    });
+  });
 
-    router.get('/ping', authHandler.isAuthenticated, function (req, res) {
-        res.render('app/ping', {
-            output: null,
-            securityRating: req.query.securityRating
-        })
-    })
+  router.get("/ping", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    res.render("app/ping", {
+      output: null,
+      securityRating: req.query.securityRating,
+    });
+  });
 
-    router.get('/bulkproducts', authHandler.isAuthenticated, function (req, res) {
-        res.render('app/bulkproducts',{legacy:req.query.legacy})
-    })
+  router.get("/bulkproducts", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    res.render("app/bulkproducts", { legacy: req.query.legacy });
+  });
 
-    router.get('/products', authHandler.isAuthenticated, appHandler.listProducts)
+  router.get("/products", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.listProducts);
 
-    router.get('/modifyproduct', authHandler.isAuthenticated, appHandler.modifyProduct)
+  router.get(
+    "/modifyproduct",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    appHandler.modifyProduct
+  );
 
-    router.get('/useredit', authHandler.isAuthenticated, appHandler.userEdit)
+  router.get("/useredit", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.userEdit);
 
-    router.get('/calc', authHandler.isAuthenticated, function (req, res) {
-        res.render('app/calc',{output:null})
-    })
+  router.get("/calc", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    res.render("app/calc", { output: null });
+  });
 
-    router.get('/admin', authHandler.isAuthenticated, function (req, res) {
-        var globalRating = ratingState[req.query.vuln]
-        res.render('app/admin', {
-            admin: (req.user.role == 'admin'),
-            securityRating: globalRating,
-            vuln: req.query.vuln
-        })
-    })
+  router.get("/admin", authHandler.isAuthenticated, authHandler.initializeRatingState, function (req, res) {
+    var globalRating = req.session.ratingState[req.query.vuln];
+    res.render("app/admin", {
+      admin: req.user.role == "admin",
+      securityRating: globalRating,
+      vuln: req.query.vuln,
+    });
+  });
 
-    router.get('/admin/usersapi/', authHandler.isAuthenticated, authHandler.isAdmin, appHandler.listUsersAPI)
+  router.get(
+    "/admin/usersapi/",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    authHandler.isAdmin,
+    appHandler.listUsersAPI
+  );
 
-    router.get('/admin/users/', authHandler.isAuthenticated, authHandler.isAdmin,function(req, res){
-        vuln3 = 'a3_sensitive_data'
-        vuln5 = 'a5_broken_access_control'
-        var a3Rating = ratingState['a3_sensitive_data']
-        var a5Rating = ratingState['a5_broken_access_control']
-        res.render('app/adminusers', {
-            a3Rating: a3Rating,
-            a5Rating: a5Rating,
-            admin: req.user.role,
-            vuln3: vuln3,
-            vuln5: vuln5
-        })
-    })
+  router.get(
+    "/admin/users/",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    authHandler.isAdmin,
+    function (req, res) {
+      vuln3 = "a3_sensitive_data";
+      vuln5 = "a5_broken_access_control";
+      var a3Rating = req.session.ratingState["a3_sensitive_data"];
+      var a5Rating = req.session.ratingState["a5_broken_access_control"];
+      res.render("app/adminusers", {
+        a3Rating: a3Rating,
+        a5Rating: a5Rating,
+        admin: req.user.role,
+        vuln3: vuln3,
+        vuln5: vuln5,
+      });
+    }
+  );
 
-    router.get('/admin/users/toggle', authHandler.isAuthenticated, function (req, res) {
-        if(ratingState[req.query.vuln] == 1)
-            ratingState[req.query.vuln] = 0
-        else
-            ratingState[req.query.vuln] = 1
-        res.redirect('/app/admin/users/')
-    })
+  router.get(
+    "/admin/users/toggle",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    function (req, res) {
+      if (req.session.ratingState[req.query.vuln] == 1)
+        req.session.ratingState[req.query.vuln] = 0;
+      else req.session.ratingState[req.query.vuln] = 1;
+      res.redirect("/app/admin/users/");
+    }
+  );
 
-    router.get('/admin/toggle/a5', authHandler.isAuthenticated, function (req, res) {
-        if(ratingState['a5_broken_access_control'] == 1)
-            ratingState['a5_broken_access_control'] = 0
-        else
-            ratingState['a5_broken_access_control'] = 1
-        res.render('app/admin', {
-            admin: (req.user.dataValues.role == 'admin'),
-            securityRating: ratingState['a5_broken_access_control'],
-            vuln: 'a5_broken_access_control'
-        })
-    })
-   
-    router.get('/redirect', appHandler.redirect)
+  router.get(
+    "/admin/toggle/a5",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    function (req, res) {
+      if (req.session.ratingState["a5_broken_access_control"] == 1)
+        req.session.ratingState["a5_broken_access_control"] = 0;
+      else req.session.ratingState["a5_broken_access_control"] = 1;
+      res.render("app/admin", {
+        admin: req.user.dataValues.role == "admin",
+        securityRating: req.session.ratingState["a5_broken_access_control"],
+        vuln: "a5_broken_access_control",
+      });
+    }
+  );
 
-    router.post('/usersearch', authHandler.isAuthenticated, appHandler.userSearch)
+  router.get("/redirect", appHandler.redirect);
 
-    router.post('/ping', authHandler.isAuthenticated, appHandler.ping)
+  router.post(
+    "/usersearch",
+    authHandler.isAuthenticated, authHandler.initializeRatingState,
+    appHandler.userSearch
+  );
 
-    router.post('/products', authHandler.isAuthenticated, appHandler.productSearch)
+  router.post("/ping", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.ping);
 
-    router.post('/modifyproduct', authHandler.isAuthenticated, appHandler.modifyProductSubmit)
+  router.post(
+    "/products",
+    authHandler.isAuthenticated, authHandler.initializeRatingState, 
+    appHandler.productSearch
+  );
 
-    router.post('/useredit', authHandler.isAuthenticated, appHandler.userEditSubmit)
+  router.post(
+    "/modifyproduct",
+    authHandler.isAuthenticated, authHandler.initializeRatingState, 
+    appHandler.modifyProductSubmit
+  );
 
-    router.get('/useredit/toggle', authHandler.isAuthenticated, function (req, res) {
-        if(ratingState[req.query.vuln] == 1)
-            ratingState[req.query.vuln] = 0
-        else
-            ratingState[req.query.vuln] = 1
-        res.redirect('/app/useredit/')
-    })
+  router.post(
+    "/useredit",
+    authHandler.isAuthenticated, authHandler.initializeRatingState, 
+    appHandler.userEditSubmit
+  );
 
-    router.post('/calc', authHandler.isAuthenticated, appHandler.calc)
+  router.get(
+    "/useredit/toggle",
+    authHandler.isAuthenticated,
+    authHandler.initializeRatingState,
+    function (req, res) {
+      if (req.session.ratingState[req.query.vuln] == 1)
+        req.session.ratingState[req.query.vuln] = 0;
+      else req.session.ratingState[req.query.vuln] = 1;
+      res.redirect("/app/useredit/");
+    }
+  );
 
-    router.post('/bulkproducts',authHandler.isAuthenticated, appHandler.bulkProducts);
+  router.post("/calc", authHandler.isAuthenticated, authHandler.initializeRatingState, appHandler.calc);
 
-    router.post('/bulkproductslegacy',authHandler.isAuthenticated, appHandler.bulkProductsLegacy);
+  router.post(
+    "/bulkproducts",
+    authHandler.isAuthenticated, authHandler.initializeRatingState, 
+    appHandler.bulkProducts
+  );
 
-    router.get('/reset-db', appHandler.resetdb);
-    
-    return router
-}
+  router.post(
+    "/bulkproductslegacy",
+    authHandler.isAuthenticated, authHandler.initializeRatingState, 
+    appHandler.bulkProductsLegacy
+  );
+
+  router.get('/reset-db', appHandler.resetdb);
+
+  return router;
+};

--- a/views/common/head.ejs
+++ b/views/common/head.ejs
@@ -10,6 +10,8 @@
 <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script type="text/javascript"
         src="https://cdnjs.cloudflare.com/ajax/libs/jquery.bootstrapvalidator/0.5.3/js/bootstrapValidator.js"></script>
+<!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" 
+      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous"> -->
 <link id="bootstrap_styles" rel="stylesheet"
       href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" type="text/css"/>
 

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -73,7 +73,7 @@
                                 <div class="  controls">
                                     <select class="selectHash" data-style="btn-info" name="pwLevel">
                                         <optgroup label="Choose Hash">
-                                            <option name="" value="4">bCrypt</option>
+                                            <option name="" value="4">bCrypt (includes a salt by default)</option>
                                             <option name="" value="3">SHA512</option>
                                             <option name="" value="2">SHA256</option>
                                             <option name="" value="1">SHA1</option>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -83,6 +83,13 @@
                                 </div>
                             </div>
 
+                            <div class="form-check form-switch form-group">
+                                <div class=" controls">
+                                    <input class="form-check-input" type="checkbox" id="saltSwitch" name="salt" value=true>
+                                    <label class="control-label form-check-label" for="saltSwitch">Add Salt</label>
+                                </div>
+                            </div>
+
 
                             <input type="hidden" id="securityRating" name="securityRating" value= <%= securityRating %>>
 


### PR DESCRIPTION
### To test this PR, please delete existing docker containers and images of both the app and the database.

## Highlights: 
1. Front end:  add an "add salt" toggle to the `register` page to allow the user to add a salt to the hash of their choice
  -  added a note to the bCrypt option that the algorithm includes a salt by default. I don't think reducing the 'rounds' used by bCrypt will get rid of the salt, so I thought this was the easiest/laziest way to address the fact that bCrypt includes one.
  - if a user selects bCrypt AND 'Add Salt', I think it doesn't break anything. It's just that an additional salt probably doesn't add much to bCrypt so you probably wouldn't do it in practice. Perhaps we can address this in the writeup. 
2. Backend, in `passport.js`:
- implement logic in the `signup` strategy in `passport.js` to provide a random 32 byte salt if the user selected "add salt"
- modify the `createHash` and `isValidPassword` functions to account for salts
- modify the User model to accept a salt String field (it's allowed to be null)
3. Other
- include the `reset-db` route to delete all Users, for testing and debugging.
- refactored `passport.js/signup` strategy a bit to eliminate duplicate logic for securityRating 0 and 1. 
- Added some postman tests to verify that various combos of hash, salt, and security rating can `register` and `login` successfully.
![image](https://user-images.githubusercontent.com/12928553/127757815-4a51cf6d-2a4d-4d6d-b1c8-52169b07af70.png)
